### PR TITLE
Avoid duplicate solutions in VS Code new project

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -27,7 +27,7 @@
   "sourceName": "MyExtensionsApp.1",
   "defaultName": "UnoApp",
   "placeholderFilename": "template-ignore",
-  "preferNameDirectory": true,
+  "preferNameDirectory": false,
   "guids": [
     "C7433AE2-B1A0-4C1A-887E-5CAA7AAF67A6", // Solution file (SolutionGuid)
     "FAA2C1DE-F859-4053-9573-6245F7E832EF", // src solution folder

--- a/src/Uno.Templates/content/unolib/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib/.template.config/template.json
@@ -24,7 +24,7 @@
   "shortName": "unolib",
   "sourceName": "CrossTargetedLibrary",
   "placeholderFilename": "template-ignore",
-  "preferNameDirectory": true,
+  "preferNameDirectory": false,
   "guids": [
     "4C26868E-5E7C-458D-82E3-040509D0C71F", // Solution file (SLN)
     "99E19497-29A6-4B77-B773-BEC55F9B55DC", // .NET Standard Library

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -22,7 +22,7 @@
   "sourceName": "MyExtensionsApp.1",
   "defaultName": "UnoMauiLibrary",
   "placeholderFilename": "template-ignore",
-  "preferNameDirectory": true,
+  "preferNameDirectory": false,
   "symbols": {
     "tfm": {
       "displayName": "Target Framework",


### PR DESCRIPTION
## Summary
- prevent nested directories by disabling `preferNameDirectory` in Uno templates

## Testing
- `dotnet build`
- `dotnet new unoapp -n TestApp2`


------
https://chatgpt.com/codex/tasks/task_e_6891e77abd5c832eadf77424f6075056